### PR TITLE
Fixed issue with string tokens parsed as vars.

### DIFF
--- a/antlang.py
+++ b/antlang.py
@@ -8,7 +8,7 @@ symbols = []
 
 def lexer(string):
 	string = re.sub(r'(\s|^)/.*\n','',string+'\n')
-	stringlit = r'"[^"]"'
+	stringlit = r'"[^"]*"'
 	num = r'\-?\d*\.?\d+'
 	frac = num + r'/' + num
 	word = r'[A-Za-z\-_]+[A-Za-z0-9\-_]*'


### PR DESCRIPTION
While playing with the examples in the Essential-AntLang book, I experienced a minor issue with strings. In the antlang repl it gave something like the following when printing the stack trace:

```
--> "some_string"
Undefined Variable
Traceback (most recent call last):
  File "antlang.py", line 251, in <module>
    print(evaluate(line))
  File "antlang.py", line 245, in evaluate
    return AntLang(do(ast))
  File "antlang.py", line 157, in do
    xast = [do(x, ws) for x in ast]
  File "antlang.py", line 157, in <listcomp>
    xast = [do(x, ws) for x in ast]
  File "antlang.py", line 230, in do
    else: raise Exception('Undefined Variable')
Exception: Undefined Variable
quit? (y/n)
```

In the Python interpreter, before the fix:

```python
>>> import antlang as ant
>>> ant.lexer('"some_string"')
[('str', ''), ('var', 'some_string'), ('str', '')]
```

After the possible fix:

```python
>>> import antlang as ant
>>> ant.lexer('"some_string"')
[('str', 'some_string')]
```


