### PR TITLE
Imported readline to ease experience at the command line

### DIFF
--- a/antlang.py
+++ b/antlang.py
@@ -5,6 +5,11 @@ import copy
 from functools import reduce
 import sys
 
+try:
+	import readline
+except ImportError:
+	pass
+
 symbols = []
 
 def lexer(string):


### PR DESCRIPTION
This is just a suggestion. On Mac OS this allows to recall the previous command and avoids to get the following when using the `up` arrow:

```
Andres-iMac:antlang4python andre$ python3 antlang.py
--> 1+2
3
--> ^[[A
```

On Windows this works natively without `readline`, and `readline` is not available on Windows, hence  the `try/catch` block surrounding the import.