### PR TITLE
Fixed issue with the check of the length of a list value.

### DIFF
--- a/antlang.py
+++ b/antlang.py
@@ -261,7 +261,7 @@ def do(ast, ws=stdlib):
 class AntLang:
 	def __init__(self, val): self.val = val
 	def __str__(self, inner = False):
-		if isinstance(self.val, list) and len(list) > 50:
+		if isinstance(self.val, list) and len(self.val) > 50:
 			return '[' + str(len(list)) + ' ELEMENTS]'
 		if isinstance(self.val, list):
 			if inner: return '(' + ' '.join(map(lambda x: AntLang(x).__str__(inner = True), self.val)) + ')'


### PR DESCRIPTION
The `len` function was called on `list` instead of `self.val` in `AntLang.__str__`, resulting in the following error message:

`object of type 'type' has no len()`

Example:

```
--> fib:{({x,0+/-2⌷x}⍣x)∘0,1}
{}
--> fib∘10
object of type 'type' has no len()
```
